### PR TITLE
openqa_label_all_tests_with_one_failing_modules: Add groupid filter

### DIFF
--- a/openqa_label_all_tests_with_one_failing_modules
+++ b/openqa_label_all_tests_with_one_failing_modules
@@ -30,6 +30,8 @@ def parse_args():
                         help="The build for which to look for a failing module")
     parser.add_argument('--module', required=True,
                         help="The failing module to look for")
+    parser.add_argument('--groupid', default=None,
+                        help="Limits labeling to this group only")
     parser.add_argument('--openqa-host', default="https://openqa.suse.de",
                         help="The openQA host to act on")
     parser.add_argument('--result',
@@ -60,14 +62,18 @@ def call(cmds, dry_run=False):
 
 
 def main():
+    request_params = {}
     args = parse_args()
     openqa_cmd = ['openqa-client', '--host', args.openqa_host, '--json-output']
     def openqa_call(cmds):
         return call(openqa_cmd + cmds, args.dry_run)
 
+    if args.groupid:
+        request_params.update({'groupid': args.groupid})
+
     log.debug("args: %s" % args)
     host = args.openqa_host if args.openqa_host.startswith('https://') else 'https://' + args.openqa_host
-    r = requests.get(urljoin(host, 'api/v1/jobs?result=%s&latest=1&scope=relevant&build=%s' % (args.result, args.build)))
+    r = requests.get(urljoin(host, 'api/v1/jobs?result=%s&latest=1&scope=relevant&build=%s' % (args.result, args.build)), params=request_params)
     r.raise_for_status()
     jobs = r.json()['jobs']
     jobs_with_failed_module = [j for j in jobs if [m for m in j['modules'] if m['name'] == args.module and m['result'] == args.result]]


### PR DESCRIPTION
Breaks your convention of parameter handling in favor of easier to read code.
Was tested by diff-ing a call with "--groupid" and one without. First job which was missing in the "without the parameter"-call was one in the virtualization job -> assuming it works without regression :)